### PR TITLE
Feat/88 비밀번호 변경 UI 구현

### DIFF
--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/controller/ApiV1CommentController.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/controller/ApiV1CommentController.java
@@ -9,6 +9,10 @@ import com.golden_dobakhe.HakPle.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -118,6 +122,19 @@ public class ApiV1CommentController {
             default:
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("댓글 삭제 실패 : 서버 오류");
         }
+    }
+    @GetMapping("/my")
+    @Operation(summary = "내 댓글 목록 조회")
+    public ResponseEntity<Page<CommentResponseDto>> getMyComments(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PageableDefault(size = 10, sort = "creationTime", direction = Sort.Direction.DESC) Pageable pageable) {
+        String userName = principal.getUser().getUserName();
+        Page<CommentResponseDto> comments = commentService.findMyComments(userName, pageable);
+
+        if (comments.isEmpty()) {
+            return ResponseEntity.ok(Page.empty()); // 빈 Page 객체 반환
+        }
+        return ResponseEntity.ok(comments);
     }
 }
 

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/repository/CommentRepository.java
@@ -1,10 +1,13 @@
 package com.golden_dobakhe.HakPle.domain.post.comment.comment.repository;
 
 import com.golden_dobakhe.HakPle.domain.post.comment.comment.entity.Comment;
+import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.global.Status;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -20,4 +23,9 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
     // 게시글 ID와 상태로 댓글 개수 조회
     @Query("SELECT COUNT(c) FROM Comment c WHERE c.board.id = :boardId AND c.status = :status")
     int countByBoardIdAndStatus(@Param("boardId") Long boardId, @Param("status") Status status);
+
+    List<Comment> findAllByUser(User user);
+
+    Page<Comment> findAllByUserAndStatus(User user,Status status,Pageable pageable);
+
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/service/CommentService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/comment/service/CommentService.java
@@ -10,11 +10,15 @@ import com.golden_dobakhe.HakPle.domain.post.post.entity.Board;
 import com.golden_dobakhe.HakPle.domain.post.post.repository.BoardRepository;
 
 
+import com.golden_dobakhe.HakPle.domain.user.exception.UserErrorCode;
+import com.golden_dobakhe.HakPle.domain.user.exception.UserException;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.domain.user.user.repository.UserRepository;
 import com.golden_dobakhe.HakPle.global.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -116,7 +120,13 @@ public class CommentService {
             return CommentResult.UNAUTHORIZED;
         }
     }
+    public Page<CommentResponseDto> findMyComments(String userName, Pageable pageable) {
+        User user = userRepository.findByUserName(userName)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
+        return commentRepository.findAllByUserAndStatus(user, Status.ACTIVE, pageable)
+                .map(CommentResponseDto::fromEntity);
+    }
 
 
 }

--- a/frontend/src/app/change-password/page.tsx
+++ b/frontend/src/app/change-password/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+// API 기본 URL
+const API_BASE_URL = 'http://localhost:8090'; // 실제 서버 URL로 변경 필요
+
+export default function ChangePasswordPage() {
+  const router = useRouter();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+  const [confirmError, setConfirmError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  
+  // 비밀번호 유효성 검사
+  const validatePassword = (password: string) => {
+    return password.length >= 8;
+  };
+  
+  // 비밀번호 확인 일치 검사
+  useEffect(() => {
+    if (newPassword && confirmPassword) {
+      if (newPassword !== confirmPassword) {
+        setConfirmError('비밀번호가 일치하지 않습니다.');
+      } else {
+        setConfirmError('');
+      }
+    } else {
+      setConfirmError('');
+    }
+  }, [newPassword, confirmPassword]);
+  
+  // 비밀번호 유효성 실시간 검사
+  useEffect(() => {
+    if (newPassword) {
+      if (!validatePassword(newPassword)) {
+        setPasswordError('비밀번호는 8자 이상이어야 합니다.');
+      } else {
+        setPasswordError('');
+      }
+    } else {
+      setPasswordError('');
+    }
+  }, [newPassword]);
+  
+  // 제출 버튼 활성화 여부
+  const isSubmitDisabled = () => {
+    return (
+      !currentPassword || 
+      !newPassword || 
+      !confirmPassword || 
+      passwordError !== '' || 
+      confirmError !== '' || 
+      isLoading
+    );
+  };
+  
+  // 비밀번호 변경 처리
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // 입력값 검증
+    if (!currentPassword) {
+      setPasswordError('현재 비밀번호를 입력해주세요.');
+      return;
+    }
+    
+    if (!validatePassword(newPassword)) {
+      setPasswordError('비밀번호는 8자 이상이어야 합니다.');
+      return;
+    }
+    
+    if (newPassword !== confirmPassword) {
+      setConfirmError('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    
+    setIsLoading(true);
+    setPasswordError('');
+    setConfirmError('');
+    
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/usernames/change-password`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${localStorage.getItem('accessToken')}`, // JWT 토큰 헤더에 추가
+        },
+        body: JSON.stringify({
+          currentPassword: currentPassword,
+          newPassword: newPassword,
+          newPasswordConfirm: confirmPassword
+        }),
+      });
+      
+      if (response.status === 401) {
+        setPasswordError('현재 비밀번호가 올바르지 않습니다.');
+        return;
+      }
+      
+      if (!response.ok) {
+        throw new Error('비밀번호 변경에 실패했습니다.');
+      }
+      
+      // 비밀번호 변경 성공 메시지 표시
+      setSuccessMessage('비밀번호가 성공적으로 변경되었습니다.');
+      
+      // 폼 리셋
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      
+      // 3초 후 메인 페이지로 이동
+      setTimeout(() => {
+        router.push('/');
+      }, 3000);
+      
+    } catch (error) {
+      console.error('비밀번호 변경 오류:', error);
+      setPasswordError('비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+  
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#FAF9FE] px-4">
+      <div className="w-full max-w-[500px] bg-white rounded-2xl p-12 shadow-md">
+        <div className="text-center mb-12">
+          <h1 className="text-3xl font-bold text-gray-900">비밀번호 변경</h1>
+          <p className="text-gray-700 mt-3 font-medium">현재 비밀번호 확인 후 새 비밀번호를 설정해주세요.</p>
+        </div>
+        
+        {successMessage && (
+          <div className="mb-6 p-4 bg-green-50 rounded-lg border border-green-200">
+            <p className="text-green-600 font-medium">{successMessage}</p>
+            <p className="text-green-600 text-sm mt-1">잠시 후 메인 페이지로 이동합니다...</p>
+          </div>
+        )}
+        
+        {passwordError && (
+          <div className="mb-6 p-4 bg-red-50 rounded-lg border border-red-200">
+            <p className="text-red-600 font-medium">{passwordError}</p>
+          </div>
+        )}
+        
+        <form onSubmit={handleSubmit} className="space-y-8">
+          <div>
+            <label htmlFor="current-password" className="block text-lg font-semibold mb-3 text-gray-800">
+              현재 비밀번호
+            </label>
+            <input
+              id="current-password"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => {
+                setCurrentPassword(e.target.value);
+                setPasswordError('');
+              }}
+              placeholder="현재 비밀번호 입력"
+              className="w-full px-6 py-5 text-lg text-black border-2 border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#8C4FF2] focus:border-transparent bg-white shadow-sm"
+              disabled={isLoading || !!successMessage}
+            />
+          </div>
+          
+          <div>
+            <label htmlFor="new-password" className="block text-lg font-semibold mb-3 text-gray-800">
+              새 비밀번호
+            </label>
+            <input
+              id="new-password"
+              type="password"
+              value={newPassword}
+              onChange={(e) => {
+                setNewPassword(e.target.value);
+              }}
+              placeholder="새 비밀번호 입력"
+              className={`w-full px-6 py-5 text-lg text-black border-2 ${
+                passwordError ? 'border-red-300' : 'border-gray-300'
+              } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#8C4FF2] focus:border-transparent bg-white shadow-sm`}
+              disabled={isLoading || !!successMessage}
+            />
+            <p className={`text-sm mt-2 ${validatePassword(newPassword) ? 'text-green-600' : 'text-gray-500'}`}>
+              비밀번호는 8자 이상이어야 합니다.
+            </p>
+          </div>
+          
+          <div>
+            <label htmlFor="confirm-password" className="block text-lg font-semibold mb-3 text-gray-800">
+              새 비밀번호 확인
+            </label>
+            <input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => {
+                setConfirmPassword(e.target.value);
+              }}
+              placeholder="새 비밀번호 다시 입력"
+              className={`w-full px-6 py-5 text-lg text-black border-2 ${
+                confirmError ? 'border-red-300' : 'border-gray-300'
+              } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#8C4FF2] focus:border-transparent bg-white shadow-sm`}
+              disabled={isLoading || !!successMessage}
+            />
+            {confirmError && (
+              <p className="text-red-500 text-sm mt-2">
+                {confirmError}
+              </p>
+            )}
+          </div>
+          
+          <div className="flex space-x-4 mt-12">
+            <button
+              type="button"
+              onClick={() => router.push('/')}
+              className="flex-1 px-6 py-5 bg-white border-2 border-gray-300 text-black text-center rounded-lg hover:bg-gray-50 transition-colors text-lg font-medium"
+              disabled={isLoading || !!successMessage}
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitDisabled()}
+              className={`flex-1 px-6 py-5 ${
+                isSubmitDisabled() 
+                  ? 'bg-gray-300 cursor-not-allowed' 
+                  : 'bg-[#8C4FF2] hover:bg-[#7340C2]'
+              } text-white rounded-lg transition-colors text-lg font-medium`}
+            >
+              {isLoading ? '처리 중...' : '변경하기'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -34,6 +34,8 @@ export default function LoginPage() {
       const data = await response.json();
       console.log('로그인 성공:', data);
       // TODO: 로그인 성공 후 처리 (예: 토큰 저장, 페이지 이동 등)
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
       
     } catch (error) {
       console.error('로그인 에러:', error);


### PR DESCRIPTION
## 📒 개요
 비밀번호 변경 UI 구현

## 📍 Issue 번호
<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
> #88

## 🛠️ 작업사항
- /login/page.tsx -> 로그인 성공시 로컬에 토큰 저장하게 함
- 토큰 사용해서 사용자 정보 가져온 뒤 비밀번호 변경
- 성공 시 성공 메시지 표시 후 3초 후 메인 페이지로 이동
- 현재 비밀번호, 새 비밀번호, 새 비밀번호 확인 입력 필드 생성

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/5e978030-7a05-492b-9a81-68e384f07198)

