### PR TITLE
Feat/102 관리자 기능 : 신고 된 게시물,댓글 목록 불러오기, 삭제

### DIFF
--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/repository/CommentReportRepository.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/repository/CommentReportRepository.java
@@ -3,11 +3,31 @@ package com.golden_dobakhe.HakPle.domain.post.comment.report.repository;
 
 import com.golden_dobakhe.HakPle.domain.post.comment.comment.entity.Comment;
 import com.golden_dobakhe.HakPle.domain.post.comment.report.entity.CommentReport;
+import com.golden_dobakhe.HakPle.domain.post.post.entity.BoardReport;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
     boolean existsByCommentAndReporter(Comment comment, User reporter);
 
+
+    @Query(value = "SELECT cr FROM CommentReport cr " +
+            "JOIN FETCH cr.comment c " +
+            "JOIN FETCH c.user u",
+            countQuery = "SELECT count(cr) FROM CommentReport cr")
+    Page<CommentReport> findAllWithUserAndComment(Pageable pageable);
+
+    @Query("SELECT br FROM BoardReport br " +
+            "JOIN FETCH br.board b " +
+            "JOIN FETCH b.user u " +
+            "ORDER BY u.reportedCount DESC")
+    List<BoardReport> findAllOrderedByReportedCount();
+
+    int countByCommentId(Long commentId);
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/service/CommentReportService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/service/CommentReportService.java
@@ -11,9 +11,11 @@ import com.golden_dobakhe.HakPle.domain.user.exception.UserException;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -30,6 +32,7 @@ public class CommentReportService {
         User user=userRepository.findById(comment.getUser().getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
+        log.info("UserReportCount : {}", user.getReportedCount());
 
 
         User reporter = userRepository.findById(userId)

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/service/CommentReportService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/service/CommentReportService.java
@@ -6,6 +6,8 @@ import com.golden_dobakhe.HakPle.domain.post.comment.comment.repository.CommentR
 import com.golden_dobakhe.HakPle.domain.post.comment.exception.CommentException;
 import com.golden_dobakhe.HakPle.domain.post.comment.report.entity.CommentReport;
 import com.golden_dobakhe.HakPle.domain.post.comment.report.repository.CommentReportRepository;
+import com.golden_dobakhe.HakPle.domain.user.exception.UserErrorCode;
+import com.golden_dobakhe.HakPle.domain.user.exception.UserException;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.domain.user.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,11 @@ public class CommentReportService {
     public void reportComment(Long commentId,Long userId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(CommentResult.COMMENT_NOT_FOUND));
+
+        User user=userRepository.findById(comment.getUser().getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
+
 
         User reporter = userRepository.findById(userId)
                 .orElseThrow(() -> new CommentException(CommentResult.USER_NOT_FOUND));

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/repository/BoardReportRepository.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/repository/BoardReportRepository.java
@@ -1,12 +1,29 @@
 package com.golden_dobakhe.HakPle.domain.post.post.repository;
 
 import com.golden_dobakhe.HakPle.domain.post.post.entity.BoardReport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface BoardReportRepository extends JpaRepository<BoardReport, Long> {
     Optional<BoardReport> findByBoardIdAndUserId(Long boardId, Long userId);
+
+    @Query("SELECT br FROM BoardReport br " +
+            "JOIN FETCH br.board b " +
+            "JOIN FETCH b.user u")
+    List<BoardReport> findAllWithUserAndBoard();
+
+    @Query(value = "SELECT br FROM BoardReport br " +
+            "JOIN FETCH br.board b " +
+            "JOIN FETCH b.user u",
+            countQuery = "SELECT count(br) FROM BoardReport br")
+    Page<BoardReport> findAllWithUserAndBoard(Pageable pageable);
+
+    int countByBoardId(Long boardId);
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/service/impl/BoardServiceImpl.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/service/impl/BoardServiceImpl.java
@@ -14,6 +14,8 @@ import com.golden_dobakhe.HakPle.domain.resource.image.repository.ImageRepositor
 
 import com.golden_dobakhe.HakPle.domain.post.comment.comment.repository.CommentRepository;
 
+import com.golden_dobakhe.HakPle.domain.user.exception.UserErrorCode;
+import com.golden_dobakhe.HakPle.domain.user.exception.UserException;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.domain.user.user.repository.UserRepository;
 import com.golden_dobakhe.HakPle.global.Status;
@@ -259,6 +261,12 @@ public class BoardServiceImpl implements BoardService {
                 .orElseThrow(() -> BoardException.notFound());
 
         board.validateStatus();
+
+        User user=userRepository.findById(board.getUser().getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
+
+
 
         if (boardReportRepository.findByBoardIdAndUserId(boardId, userId).isPresent()) {
             throw BoardException.invalidRequest();

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/controller/ApiV1AdminController.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/controller/ApiV1AdminController.java
@@ -49,6 +49,19 @@ public class ApiV1AdminController {
         return ResponseEntity.ok(academyCode);
     }
 
+    @PostMapping("/boards/{id}/pending")
+    @Operation(summary = "게시글 상태를 PENDING으로 변경", description = "신고된 게시글을 PENDING 상태로 변경합니다.")
+    public ResponseEntity<Void> setBoardPending(@PathVariable(name = "id") Long id) {
+        adminService.setBoardPending(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/comments/{id}/pending")
+    @Operation(summary = "댓글 상태를 PENDING으로 변경", description = "신고된 댓글을 PENDING 상태로 변경합니다.")
+    public ResponseEntity<Void> setCommentPending(@PathVariable(name = "id")  Long id) {
+        adminService.setCommentPending(id);
+        return ResponseEntity.ok().build();
+    }
 }
 
 

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/controller/ApiV1ReportAdminController.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/controller/ApiV1ReportAdminController.java
@@ -1,0 +1,67 @@
+package com.golden_dobakhe.HakPle.domain.user.admin.controller;
+
+import com.golden_dobakhe.HakPle.domain.user.admin.dto.BoardReportDto;
+import com.golden_dobakhe.HakPle.domain.user.admin.dto.CommentReportDto;
+import com.golden_dobakhe.HakPle.domain.user.admin.service.BoardReportService;
+import com.golden_dobakhe.HakPle.domain.user.admin.service.CommentReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/v1/admin/report")
+@RequiredArgsConstructor
+@Tag(name = "🚨 신고 관리", description = "신고된 댓글 및 게시글 관련 API")
+public class ApiV1ReportAdminController {
+
+    @Qualifier("adminCommentReportService")
+    private final CommentReportService commentReportService;
+    private final BoardReportService boardReportService;
+
+    @GetMapping("/comments")
+    @Operation(
+            summary = "신고된 댓글 목록 조회",
+            description = "페이징 정보를 기반으로 신고된 댓글 리스트를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음")
+            }
+    )
+    public Page<CommentReportDto> getReportedComments(
+            @Parameter(description = "페이지 번호", example = "0") @RequestParam(name ="page",defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(name = "size",defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "creationTime"));
+        return commentReportService.getReportedComments(pageable);
+    }
+
+    @GetMapping("/boards")
+    @Operation(
+            summary = "신고된 게시글 목록 조회",
+            description = "신고된 게시글과 신고당한 유저의 정보를 페이징하여 반환합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음")
+            }
+    )
+    public Page<BoardReportDto> getReportedBoards(
+            @Parameter(description = "페이지 번호", example = "0") @RequestParam(name ="page",defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기", example = "10") @RequestParam(name = "size",defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "creationTime"));
+        return boardReportService.getReportedBoards(pageable);
+    }
+
+}
+

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/dto/BoardReportDto.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/dto/BoardReportDto.java
@@ -1,0 +1,53 @@
+package com.golden_dobakhe.HakPle.domain.user.admin.dto;
+
+import com.golden_dobakhe.HakPle.domain.post.post.entity.BoardReport;
+import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "신고된 게시물 정보 DTO")
+public class BoardReportDto {
+
+    @Schema(description = "신고 ID", example = "1")
+    private Long reportId;
+
+    @Schema(description = "신고된 게시글  ID", example = "42")
+    private Long boardId;
+
+    @Schema(description = "신고된 게시글 제목", example = "제목입니다")
+    private String boardTitle;
+
+    @Schema(description = "댓글 작성자 ID", example = "5")
+    private Long reportedUserId;
+
+    @Schema(description = "해당 사용자가 받은 총 신고 횟수", example = "3")
+    private int userReportedCount;
+
+    @Schema(description = "이 게시글이 받은 신고 횟수", example = "4")
+    private int boardReportedCount;
+
+    @Schema(description = "신고 일시", example = "2025-04-19T12:34:56")
+    private LocalDateTime reportedAt;
+
+    public static BoardReportDto fromEntity(BoardReport report,int boardReportCount) {
+        User user = report.getBoard().getUser();
+        return new BoardReportDto(
+                report.getId(),
+                report.getBoard().getId(),
+                report.getBoard().getTitle(),
+                user.getId(),
+                user.getReportedCount(),
+                boardReportCount,
+                report.getCreationTime()
+        );
+    }
+}
+

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/dto/CommentReportDto.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/dto/CommentReportDto.java
@@ -1,0 +1,49 @@
+package com.golden_dobakhe.HakPle.domain.user.admin.dto;
+
+import com.golden_dobakhe.HakPle.domain.post.comment.report.entity.CommentReport;
+import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentReportDto {
+    @Schema(description = "신고 ID", example = "1")
+    private Long reportId;
+
+    @Schema(description = "신고된 댓글 ID", example = "42")
+    private Long commentId;
+
+    @Schema(description = "신고된 댓글 내용", example = "이 댓글은 부적절합니다.")
+    private String commentContent;
+
+    @Schema(description = "댓글 작성자 ID", example = "5")
+    private Long reportedUserId;
+
+    @Schema(description = "해당 사용자가 받은 총 신고 횟수", example = "3")
+    private int userReportedCount;
+
+    @Schema(description = "이 댓글이 받은 신고 횟수", example = "3")
+    private int commentReportedCount;
+
+    @Schema(description = "신고 일시", example = "2025-04-19T12:34:56")
+    private LocalDateTime reportedAt;
+
+    public static CommentReportDto fromEntity(CommentReport report,int commentReportCount) {
+        User user= report.getComment().getUser();
+        return CommentReportDto.builder()
+                .reportId(report.getId())
+                .commentId(report.getComment().getId())
+                .commentContent(report.getComment().getContent())
+                .reportedUserId(report.getComment().getUser().getId())
+                .userReportedCount(user.getReportedCount())
+                .reportedAt(report.getCreationTime())
+                .commentReportedCount(commentReportCount)
+                .build();
+    }
+
+}
+

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/dto/CommentReportDto.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/dto/CommentReportDto.java
@@ -1,6 +1,7 @@
 package com.golden_dobakhe.HakPle.domain.user.admin.dto;
 
 import com.golden_dobakhe.HakPle.domain.post.comment.report.entity.CommentReport;
+import com.golden_dobakhe.HakPle.domain.post.post.entity.Board;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -23,6 +24,9 @@ public class CommentReportDto {
     @Schema(description = "댓글 작성자 ID", example = "5")
     private Long reportedUserId;
 
+    @Schema(description = "게시물 ID")
+    private Long boardId;
+
     @Schema(description = "해당 사용자가 받은 총 신고 횟수", example = "3")
     private int userReportedCount;
 
@@ -34,6 +38,7 @@ public class CommentReportDto {
 
     public static CommentReportDto fromEntity(CommentReport report,int commentReportCount) {
         User user= report.getComment().getUser();
+        Board board = report.getComment().getBoard();
         return CommentReportDto.builder()
                 .reportId(report.getId())
                 .commentId(report.getComment().getId())
@@ -42,6 +47,7 @@ public class CommentReportDto {
                 .userReportedCount(user.getReportedCount())
                 .reportedAt(report.getCreationTime())
                 .commentReportedCount(commentReportCount)
+                .boardId(board.getId())
                 .build();
     }
 

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/service/AdminService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/service/AdminService.java
@@ -1,5 +1,12 @@
 package com.golden_dobakhe.HakPle.domain.user.admin.service;
 
+import com.golden_dobakhe.HakPle.domain.post.comment.CommentResult;
+import com.golden_dobakhe.HakPle.domain.post.comment.comment.entity.Comment;
+import com.golden_dobakhe.HakPle.domain.post.comment.comment.repository.CommentRepository;
+import com.golden_dobakhe.HakPle.domain.post.comment.exception.CommentException;
+import com.golden_dobakhe.HakPle.domain.post.post.entity.Board;
+import com.golden_dobakhe.HakPle.domain.post.post.exception.BoardException;
+import com.golden_dobakhe.HakPle.domain.post.post.repository.BoardRepository;
 import com.golden_dobakhe.HakPle.domain.user.admin.dto.AcademyRequestDto;
 import com.golden_dobakhe.HakPle.domain.user.admin.dto.AdminLoginDto;
 import com.golden_dobakhe.HakPle.domain.user.admin.dto.AdminRegisterDto;
@@ -33,6 +40,8 @@ public class AdminService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenizer jwtTokenizer;
     private final AcademyRepository academyRepository;
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
 
     public String registerAdmin(AdminRegisterDto dto) {
         if (userRepository.existsByUserName(dto.getUserName())) {
@@ -135,5 +144,16 @@ public class AdminService {
         academyRepository.save(academy);
         return code;
     }
-
+    //게시물 삭제 처리
+    public void setBoardPending(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> BoardException.notFound("해당 게시물이 존재하지 않습니다"));
+        board.setStatus(Status.PENDING);
+    }
+    //댓글 삭제 처리
+    public void setCommentPending(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(CommentResult.COMMENT_NOT_FOUND));
+        comment.setStatus(Status.PENDING);
+    }
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/service/BoardReportService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/service/BoardReportService.java
@@ -1,0 +1,23 @@
+package com.golden_dobakhe.HakPle.domain.user.admin.service;
+
+import com.golden_dobakhe.HakPle.domain.post.post.repository.BoardReportRepository;
+import com.golden_dobakhe.HakPle.domain.user.admin.dto.BoardReportDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardReportService {
+    private final BoardReportRepository boardReportRepository;
+
+    public Page<BoardReportDto> getReportedBoards(Pageable pageable) {
+        return boardReportRepository.findAllWithUserAndBoard(pageable)
+                .map(report -> {
+                    Long boardId = report.getBoard().getId();
+                    int boardReportCount = boardReportRepository.countByBoardId(boardId);
+                    return BoardReportDto.fromEntity(report, boardReportCount);
+                });
+    }
+}

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/service/CommentReportService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/service/CommentReportService.java
@@ -1,0 +1,24 @@
+package com.golden_dobakhe.HakPle.domain.user.admin.service;
+
+import com.golden_dobakhe.HakPle.domain.post.comment.report.repository.CommentReportRepository;
+import com.golden_dobakhe.HakPle.domain.user.admin.dto.BoardReportDto;
+import com.golden_dobakhe.HakPle.domain.user.admin.dto.CommentReportDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service("adminCommentReportService")
+@RequiredArgsConstructor
+public class CommentReportService {
+    private final CommentReportRepository commentReportRepository;
+
+    public Page<CommentReportDto> getReportedComments(Pageable pageable) {
+        return commentReportRepository.findAllWithUserAndComment(pageable)
+                .map(report -> {
+                    Long commentId = report.getComment().getId();
+                    int commentReportCount = commentReportRepository.countByCommentId(commentId);
+                    return CommentReportDto.fromEntity(report, commentReportCount);
+                });
+    }
+}

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/user/entity/User.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/user/entity/User.java
@@ -56,4 +56,7 @@ public class User extends BaseEntity {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "profile_image_id", referencedColumnName = "id")
     private Image profileImage; // 프로필 이미지 (Image 엔티티와 연결)
+
+    @Column(name = "reported_count")
+    private int reportedCount; // 신고 누적 수
 }


### PR DESCRIPTION
## 📒 개요

- 관리자 기능: 신고된 게시물 및 댓글 목록 불러오기
- 관리자 기능: 게시물 및 댓글 삭제 기능 추가(Soft Delete)

## 📍 Issue 번호
<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
> #102

## 🛠️ 작업사항
<!-- 내용을 적어주세요. -->

✅ 관리자 신고 관리 기능 구현
신고된 게시물/댓글 목록 조회 (페이징, 최신순)
신고된 게시물/댓글 상태 PENDING으로 변경

✅ 응답에 포함되는 추가 정보
게시물/댓글 작성자의 아이디
신고 횟수 (해당 게시물/댓글이 몇 번 신고받았는지)
작성자의 총 신고 누적 횟수 등등

## 📸 스크린샷(선택)
