### PR TITLE
Feat/104 관리자 모드 신고 댓글,게시물 관리

### DIFF
--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/like/controller/ApiV1LikeController.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/like/controller/ApiV1LikeController.java
@@ -75,25 +75,25 @@ public class ApiV1LikeController {
         return ResponseEntity.ok(likeService.likeCount(commentId));
     }
 
-    @Operation(summary = "내가 좋아요 누른 댓글 목록", description = "로그인한 사용자가 좋아요한 댓글 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "목록 조회 성공")
-    @GetMapping("/my/comments")
-    public ResponseEntity<List<LikedCommentDto>> getMyLikedComments(
-            @AuthenticationPrincipal CustomUserDetails principal
-    ) {
-        User user = principal.getUser();
-        return ResponseEntity.ok(likeService.userLikedComments(user.getId()));
-    }
-
-    @Operation(summary = "내가 좋아요 누른 댓글 수", description = "로그인한 사용자가 좋아요한 댓글 수를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "카운트 조회 성공")
-    @GetMapping("/my/comments/count")
-    public ResponseEntity<Integer> getMyLikedCommentCount(
-            @AuthenticationPrincipal CustomUserDetails principal
-    ) {
-        User user = principal.getUser();
-        return ResponseEntity.ok(likeService.countUserLikedComments(user.getId()));
-    }
+//    @Operation(summary = "내가 좋아요 누른 댓글 목록", description = "로그인한 사용자가 좋아요한 댓글 목록을 조회합니다.")
+//    @ApiResponse(responseCode = "200", description = "목록 조회 성공")
+//    @GetMapping("/my/comments")
+//    public ResponseEntity<List<LikedCommentDto>> getMyLikedComments(
+//            @AuthenticationPrincipal CustomUserDetails principal
+//    ) {
+//        User user = principal.getUser();
+//        return ResponseEntity.ok(likeService.userLikedComments(user.getId()));
+//    }
+//
+//    @Operation(summary = "내가 좋아요 누른 댓글 수", description = "로그인한 사용자가 좋아요한 댓글 수를 조회합니다.")
+//    @ApiResponse(responseCode = "200", description = "카운트 조회 성공")
+//    @GetMapping("/my/comments/count")
+//    public ResponseEntity<Integer> getMyLikedCommentCount(
+//            @AuthenticationPrincipal CustomUserDetails principal
+//    ) {
+//        User user = principal.getUser();
+//        return ResponseEntity.ok(likeService.countUserLikedComments(user.getId()));
+//    }
 
     @DeleteMapping("/comments/{commentId}")
     @Operation(summary = "댓글 좋아요 취소", description = "이미 좋아요 누른 댓글만 취소 가능")

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/like/service/LikeService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/like/service/LikeService.java
@@ -114,23 +114,23 @@ public class LikeService {
         return comment.getLikeCount();
     }
 
-    //회원 별 좋아요 누른 댓글
-    public List<LikedCommentDto> userLikedComments(Long userId) {
-        return userRepository.findById(userId)
-                .map(user -> likeRepository.findByUserId(user.getId()).stream()
-                        .map(CommentLike::getComment)
-                        .map(comment -> new LikedCommentDto(
-                                comment.getId(),
-                                comment.getContent()
-                        ))
-                        .collect(Collectors.toList()))
-                .orElse(Collections.emptyList());
-    }
-
-    //회원 별 좋아요 누른 댓글 갯수
-    public int countUserLikedComments(Long userId) {
-        return userRepository.findById(userId)
-                .map(user ->  likeRepository.findByUserId(user.getId()).size())
-                .orElse(0);
-    }
+//    //회원 별 좋아요 누른 댓글
+//    public List<LikedCommentDto> userLikedComments(Long userId) {
+//        return userRepository.findById(userId)
+//                .map(user -> likeRepository.findByUserId(user.getId()).stream()
+//                        .map(CommentLike::getComment)
+//                        .map(comment -> new LikedCommentDto(
+//                                comment.getId(),
+//                                comment.getContent()
+//                        ))
+//                        .collect(Collectors.toList()))
+//                .orElse(Collections.emptyList());
+//    }
+//
+//    //회원 별 좋아요 누른 댓글 갯수
+//    public int countUserLikedComments(Long userId) {
+//        return userRepository.findById(userId)
+//                .map(user ->  likeRepository.findByUserId(user.getId()).size())
+//                .orElse(0);
+//    }
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/repository/CommentReportRepository.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/repository/CommentReportRepository.java
@@ -15,14 +15,6 @@ import java.util.List;
 public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 
     boolean existsByCommentAndReporter(Comment comment, User reporter);
-
-
-    @Query(value = "SELECT cr FROM CommentReport cr " +
-            "JOIN FETCH cr.comment c " +
-            "JOIN FETCH c.user u",
-            countQuery = "SELECT count(cr) FROM CommentReport cr")
-    Page<CommentReport> findAllWithUserAndComment(Pageable pageable);
-
     @Query("SELECT br FROM BoardReport br " +
             "JOIN FETCH br.board b " +
             "JOIN FETCH b.user u " +
@@ -30,4 +22,13 @@ public interface CommentReportRepository extends JpaRepository<CommentReport, Lo
     List<BoardReport> findAllOrderedByReportedCount();
 
     int countByCommentId(Long commentId);
+
+    @Query("""
+    SELECT cr FROM CommentReport cr
+    JOIN FETCH cr.comment c
+    JOIN FETCH cr.reporter u
+    WHERE c.status = 'INACTIVE'
+    """)//INACTIVE 조건 추가
+    Page<CommentReport> findAllWithUserAndComment(Pageable pageable);
+
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/service/CommentReportService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/comment/report/service/CommentReportService.java
@@ -10,6 +10,7 @@ import com.golden_dobakhe.HakPle.domain.user.exception.UserErrorCode;
 import com.golden_dobakhe.HakPle.domain.user.exception.UserException;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.domain.user.user.repository.UserRepository;
+import com.golden_dobakhe.HakPle.global.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,9 +32,6 @@ public class CommentReportService {
 
         User user=userRepository.findById(comment.getUser().getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
-        log.info("UserReportCount : {}", user.getReportedCount());
-
 
         User reporter = userRepository.findById(userId)
                 .orElseThrow(() -> new CommentException(CommentResult.USER_NOT_FOUND));
@@ -48,6 +46,11 @@ public class CommentReportService {
                 .comment(comment)
                 .reporter(reporter)
                 .build();
+
+        user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
+        log.info("UserReportCount : {}", user.getReportedCount());
+
+        comment.setStatus(Status.INACTIVE); //대기 상태로 변경
 
         reportRepository.save(report);
     }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/repository/BoardReportRepository.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/repository/BoardReportRepository.java
@@ -19,11 +19,14 @@ public interface BoardReportRepository extends JpaRepository<BoardReport, Long> 
             "JOIN FETCH b.user u")
     List<BoardReport> findAllWithUserAndBoard();
 
-    @Query(value = "SELECT br FROM BoardReport br " +
-            "JOIN FETCH br.board b " +
-            "JOIN FETCH b.user u",
-            countQuery = "SELECT count(br) FROM BoardReport br")
+    @Query("""
+    SELECT br FROM BoardReport br
+    JOIN FETCH br.board b
+    JOIN FETCH br.user u
+    WHERE b.status = 'INACTIVE'
+    """) //INACTIVE 조건 추가
     Page<BoardReport> findAllWithUserAndBoard(Pageable pageable);
+
 
     int countByBoardId(Long boardId);
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/service/impl/BoardServiceImpl.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/post/post/service/impl/BoardServiceImpl.java
@@ -267,10 +267,6 @@ public class BoardServiceImpl implements BoardService {
 
         User user=userRepository.findById(board.getUser().getId()).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
-        user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
-
-
-
         if (boardReportRepository.findByBoardIdAndUserId(boardId, userId).isPresent()) {
             throw BoardException.invalidRequest();
         }
@@ -281,6 +277,10 @@ public class BoardServiceImpl implements BoardService {
                 .user(userRepository.findById(userId)
                         .orElseThrow(() -> BoardException.notFound()))
                 .build();
+
+        user.setReportedCount(user.getReportedCount() + 1); //신고 횟수 누적
+        board.setStatus(Status.INACTIVE); //대기 상태로 변경
+
 
         boardReportRepository.save(boardReport);
     }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/controller/ApiV1AdminController.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/admin/controller/ApiV1AdminController.java
@@ -4,15 +4,21 @@ import com.golden_dobakhe.HakPle.domain.user.admin.dto.AcademyRequestDto;
 import com.golden_dobakhe.HakPle.domain.user.admin.dto.AdminLoginDto;
 import com.golden_dobakhe.HakPle.domain.user.admin.dto.AdminRegisterDto;
 import com.golden_dobakhe.HakPle.domain.user.admin.service.AdminService;
+import com.golden_dobakhe.HakPle.domain.user.user.entity.Role;
+import com.golden_dobakhe.HakPle.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 
+
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/admin")
 @RequiredArgsConstructor
@@ -62,6 +68,20 @@ public class ApiV1AdminController {
         adminService.setCommentPending(id);
         return ResponseEntity.ok().build();
     }
+    @GetMapping("/check")
+    @Operation(summary = "관리자인지 확인",description = "사용자가 관리자 권한을 가지고 있는지 확인합니다")
+    public ResponseEntity<?> checkAdmin(@AuthenticationPrincipal CustomUserDetails principal) {
+
+        boolean isAdmin = principal.getUser().getRoles()
+                .stream()
+                .anyMatch(role -> role.equals(Role.ADMIN));
+
+        log.info(principal.getUser().getRoles().toString());
+
+        return ResponseEntity.ok(isAdmin);
+    }
+
+
 }
 
 

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/domain/user/user/repository/UserRepository.java
@@ -2,10 +2,15 @@ package com.golden_dobakhe.HakPle.domain.user.user.repository;
 
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    @EntityGraph(attributePaths = "roles")
     Optional<User> findByUserName(String userName);
 
     boolean existsByUserName(String userName); //아이디 중복확인
@@ -15,4 +20,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByPhoneNum(String phoneNum);
 
     Optional<User> findByNickNameAndPhoneNum(String nickName, String phoneNum);
+
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.roles WHERE u.userName = :username")
+    Optional<User> findByUserNameWithRoles(@Param("username") String username);
+
+    @EntityGraph(attributePaths = "roles") // 🎯 roles 컬렉션을 함께 로딩
+    @Query("SELECT u FROM User u WHERE u.id = :id")
+    Optional<User> findByIdWithRoles(@Param("id") Long id);
+
 }

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/security/CustomUserDetails.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/security/CustomUserDetails.java
@@ -9,7 +9,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 @Getter
 public class CustomUserDetails implements UserDetails {
@@ -17,12 +18,17 @@ public class CustomUserDetails implements UserDetails {
 
     public CustomUserDetails(User user) {
         this.user = user;
+        System.out.println("💡 [DEBUG] 유저 생성됨: roles = " + user.getRoles());
     }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        String role = "ROLE_" + user.getStatus().name(); // 예: ROLE_ACTIVE
-        return List.of(new SimpleGrantedAuthority(role));
+        if (user.getRoles() == null) {
+            return Collections.emptyList(); // 혹은 로그 찍고 예외 던져도 됨
+        }
+
+        return user.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.name()))
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/security/CustomUserDetailsService.java
@@ -24,13 +24,13 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository; // 또는 TestRepository
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUserName(username)
-                .orElseThrow(() -> new UsernameNotFoundException(username + " 없어요"));
+    public UserDetails loadUserByUsername(String username) {
+        log.info("loadUserByUsername: {}", username);
+        User user = userRepository.findByUserNameWithRoles(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
-      //쓰는 곳이 없어서 일단은 리턴값을 null로 했습니다
-        return null;
-
+        log.info("✅ User loaded: " + user.getUserName() + ", roles = " + user.getRoles());
+        return new com.golden_dobakhe.HakPle.security.CustomUserDetails(user); // 이 시점에 roles가 null이면 안 됨!
     }
 
     //user객체만 가져오는 방식이랑 원하는 부분만 가져오는 방식에서 문제가 생겨서 이렇게 나누었습니다

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -20,13 +20,60 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
         logoutAndHome,
     }
 
+    // URL 쿼리 파라미터에서 토큰 확인
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            // URL 쿼리 파라미터 파싱
+            const urlParams = new URLSearchParams(window.location.search);
+            const accessToken = urlParams.get('accessToken');
+            const refreshToken = urlParams.get('refreshToken');
+            
+            // URL에 토큰이 있으면 저장
+            if (accessToken) {
+                console.log('URL에서 액세스 토큰 발견, 저장합니다');
+                localStorage.setItem('accessToken', accessToken);
+            }
+            
+            if (refreshToken) {
+                console.log('URL에서 리프레시 토큰 발견, 저장합니다');
+                localStorage.setItem('refreshToken', refreshToken);
+            }
+            
+            // 토큰이 있었다면 현재 URL에서 토큰 파라미터 제거 (보안상 이유로)
+            if (accessToken || refreshToken) {
+                // 현재 URL에서 토큰 쿼리 파라미터를 제거하고 히스토리에 추가하지 않음
+                const cleanUrl = window.location.pathname + window.location.hash;
+                window.history.replaceState({}, document.title, cleanUrl);
+            }
+        }
+    }, []);
+
     //[]최초 요청시 api를 보낸다, 요청시에도 저게 돌아간다고 한다
     useEffect(() => {
         console.log('ClientLayout - 로그인 상태 확인 시작')
+        
+        if (typeof window === 'undefined') {
+            // 서버 사이드에서는 실행하지 않음
+            return;
+        }
+        
+        // 로컬 스토리지에서 액세스 토큰 확인
+        const accessToken = localStorage.getItem('accessToken')
+        console.log('ClientLayout - 액세스 토큰 확인:', !!accessToken)
+        
+        if (!accessToken) {
+            console.log('ClientLayout - 액세스 토큰 없음, 로그인 상태 아님')
+            setNoLoginMember()
+            return
+        }
 
-        fetch('/api/v1/auth/me', {
+        fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/auth/me`, {
             //요청마다 헤더에 쿠키가 자동 실행된다고 한다
             credentials: 'include',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json'
+            }
         })
             .then((res) => {
                 console.log('로그인 상태 응답:', res.status)
@@ -43,6 +90,8 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
             .catch((error) => {
                 //로그인이 안되있다면
                 console.error('로그인 상태 확인 에러:', error)
+                // 에러 발생 시 토큰 삭제
+                localStorage.removeItem('accessToken')
                 setNoLoginMember()
             })
             .finally(() => {

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function AdminPage() {
+  const router = useRouter();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [debugInfo, setDebugInfo] = useState<any>(null);
+
+  useEffect(() => {
+    const checkAdmin = async () => {
+      try {
+        // 로컬 스토리지에서 액세스 토큰 가져오기
+        const token = localStorage.getItem('accessToken');
+        console.log('Token found:', !!token);
+        
+        if (!token) {
+          console.log('No token found, redirecting to login');
+          setDebugInfo({ error: 'No token found' });
+          router.push('/login');
+          return;
+        }
+        
+        console.log('Checking admin status, API URL:', `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/check`);
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/check`, {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}` // 인증 토큰 추가
+          },
+        });
+
+        console.log('Admin check response status:', response.status);
+        if (!response.ok) {
+          console.log('Admin check failed, status:', response.status);
+          setDebugInfo({ 
+            error: 'Admin check failed', 
+            status: response.status,
+            statusText: response.statusText 
+          });
+          router.push('/');
+          return;
+        }
+
+        // 응답 데이터 처리
+        const isAdminResult = await response.json();
+        console.log('Admin check result:', isAdminResult);
+        
+        // boolean 값을 확인하여 관리자 권한 설정
+        if (isAdminResult === true) {
+          console.log('User is admin, showing admin page');
+          setIsAdmin(true);
+          setDebugInfo({ isAdmin: true, message: 'Admin permissions confirmed' });
+        } else {
+          console.log('User is not admin, redirecting to home');
+          setDebugInfo({ isAdmin: false, message: 'Not an admin user' });
+          // 관리자가 아니면 홈으로 이동
+          router.push('/');
+        }
+      } catch (error) {
+        console.error('관리자 권한 확인 중 오류 발생:', error);
+        setDebugInfo({ error: 'Error checking admin status', details: error });
+        router.push('/');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    checkAdmin();
+  }, [router]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  // 디버깅 정보 표시
+  if (debugInfo && !isAdmin) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-4">관리자 권한 확인 실패</h1>
+        <div className="bg-red-50 border border-red-200 p-4 rounded-md">
+          <pre className="whitespace-pre-wrap overflow-auto">
+            {JSON.stringify(debugInfo, null, 2)}
+          </pre>
+        </div>
+        <div className="mt-4">
+          <button 
+            onClick={() => router.push('/')}
+            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          >
+            홈으로 돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-8">🔑관리자 페이지</h1>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <Link href="/admin/reports/comments" className="block p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition">
+          <h2 className="text-xl font-semibold mb-2">💬댓글 관리</h2>
+          <p className="text-gray-600">신고된 댓글을 관리합니다</p>
+        </Link>
+        
+        <Link href="/admin/reports/posts" className="block p-6 bg-white rounded-lg shadow-md hover:shadow-lg transition">
+          <h2 className="text-xl font-semibold mb-2">📃게시글 관리</h2>
+          <p className="text-gray-600">신고된 게시글을 관리합니다</p>
+        </Link>
+      </div>
+    </div>
+  );
+} 

--- a/frontend/src/app/admin/reports/comments/page.tsx
+++ b/frontend/src/app/admin/reports/comments/page.tsx
@@ -1,0 +1,284 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface ReportedComment {
+  reportId: number;
+  commentId: number;
+  commentContent: string;
+  reportedUserId: number;
+  boardId: number;
+  userReportedCount: number;
+  commentReportedCount: number;
+  reportedAt: string;
+}
+
+export default function ReportedCommentsPage() {
+  const router = useRouter();
+  const [comments, setComments] = useState<ReportedComment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [processingIds, setProcessingIds] = useState<number[]>([]);
+  const [token, setToken] = useState<string | null>(null);
+  
+  const PAGE_SIZE = 10;
+
+  useEffect(() => {
+    // 컴포넌트 마운트 시 토큰 가져오기
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      router.push('/login');
+      return;
+    }
+    
+    setToken(accessToken);
+    checkAdmin(accessToken);
+  }, [router]);
+
+  const checkAdmin = async (accessToken: string) => {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/check`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`
+        },
+      });
+
+      if (!response.ok) {
+        router.push('/');
+        return;
+      }
+
+      // 응답 데이터 처리
+      const isAdminResult = await response.json();
+      
+      // boolean 값을 확인하여 관리자 권한 설정
+      if (isAdminResult === true) {
+        setIsAdmin(true);
+        fetchComments(0, accessToken);
+      } else {
+        // 관리자가 아니면 홈으로 이동
+        router.push('/');
+      }
+    } catch (error) {
+      console.error('관리자 권한 확인 중 오류 발생:', error);
+      router.push('/');
+    }
+  };
+
+  const fetchComments = async (page: number, accessToken: string) => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/report/comments?page=${page}&size=${PAGE_SIZE}`,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('데이터를 불러오는데 실패했습니다');
+      }
+
+      const data = await response.json();
+      setComments(data.content || []);
+      setTotalPages(data.totalPages || 1);
+      setCurrentPage(page);
+    } catch (error) {
+      console.error('댓글 데이터 로드 중 오류 발생:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    if (page < 0 || page >= totalPages || !token) return;
+    fetchComments(page, token);
+  };
+
+  const handleDeleteComment = async (commentId: number) => {
+    if (processingIds.includes(commentId) || !token) return;
+    
+    setProcessingIds(prev => [...prev, commentId]);
+    
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/comments/${commentId}/pending`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('댓글 삭제 처리 중 오류가 발생했습니다');
+      }
+
+      // 성공 후 목록에서 해당 댓글 제거
+      setComments(prev => prev.filter(comment => comment.commentId !== commentId));
+    } catch (error) {
+      console.error('댓글 삭제 처리 중 오류:', error);
+      alert('댓글 삭제 처리에 실패했습니다.');
+    } finally {
+      setProcessingIds(prev => prev.filter(id => id !== commentId));
+    }
+  };
+
+  if (loading && !comments.length) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  const displayPage = currentPage + 1;
+  const displayTotalPages = totalPages;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6 flex justify-between items-center">
+        <h1 className="text-2xl font-bold">신고된 댓글 관리</h1>
+        <Link href="/admin" className="text-blue-600 hover:underline">
+          관리자 홈으로
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center my-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
+        </div>
+      ) : comments.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border border-gray-200">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="py-2 px-3 border-b text-left">신고 ID</th>
+                <th className="py-2 px-3 border-b text-left">댓글 ID</th>
+                <th className="py-2 px-3 border-b text-left">댓글 내용</th>
+                <th className="py-2 px-3 border-b text-left">작성자 ID</th>
+                <th className="py-2 px-3 border-b text-left">해당 유저 총 신고 횟수</th>
+                <th className="py-2 px-3 border-b text-left">해당 댓글 신고 횟수</th>
+                <th className="py-2 px-3 border-b text-left">신고 일시</th>
+                <th className="py-2 px-3 border-b text-left">관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comments.map((comment) => (
+                <tr key={comment.reportId} className="hover:bg-gray-50">
+                  <td className="py-2 px-3 border-b">{comment.reportId}</td>
+                  <td className="py-2 px-3 border-b">{comment.commentId}</td>
+                  <td className="py-2 px-3 border-b max-w-xs truncate">
+                    <Link 
+                      href={`/post/${comment.boardId}`} 
+                      className="text-blue-600 hover:underline cursor-pointer"
+                    >
+                      {comment.commentContent}
+                    </Link>
+                  </td>
+                  <td className="py-2 px-3 border-b">
+                    <Link 
+                      href={`/admin/users/${comment.reportedUserId}`} 
+                      className="text-blue-600 hover:underline"
+                    >
+                      {comment.reportedUserId}
+                    </Link>
+                  </td>
+                  <td className="py-2 px-3 border-b">{comment.userReportedCount}</td>
+                  <td className="py-2 px-3 border-b">{comment.commentReportedCount}</td>
+                  <td className="py-2 px-3 border-b">
+                    {new Date(comment.reportedAt).toLocaleString('ko-KR')}
+                  </td>
+                  <td className="py-2 px-3 border-b">
+                    <button
+                      onClick={() => handleDeleteComment(comment.commentId)}
+                      disabled={processingIds.includes(comment.commentId)}
+                      className={`px-3 py-1 rounded text-white ${
+                        processingIds.includes(comment.commentId)
+                          ? 'bg-gray-400'
+                          : 'bg-red-500 hover:bg-red-600'
+                      }`}
+                    >
+                      {processingIds.includes(comment.commentId) ? '처리 중...' : '삭제'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="text-center py-8">
+          <p className="text-gray-500">신고된 댓글이 없습니다.</p>
+        </div>
+      )}
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex justify-center mt-6">
+          <nav>
+            <ul className="flex">
+              <li>
+                <button
+                  onClick={() => handlePageChange(currentPage - 1)}
+                  disabled={currentPage === 0}
+                  className={`mx-1 px-3 py-1 rounded ${
+                    currentPage === 0
+                      ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                      : 'bg-gray-200 hover:bg-gray-300'
+                  }`}
+                >
+                  이전
+                </button>
+              </li>
+              {Array.from({ length: displayTotalPages }, (_, i) => i).map((page) => (
+                <li key={page}>
+                  <button
+                    onClick={() => handlePageChange(page)}
+                    className={`mx-1 px-3 py-1 rounded ${
+                      currentPage === page ? 'bg-blue-500 text-white' : 'bg-gray-200 hover:bg-gray-300'
+                    }`}
+                  >
+                    {page + 1}
+                  </button>
+                </li>
+              ))}
+              <li>
+                <button
+                  onClick={() => handlePageChange(currentPage + 1)}
+                  disabled={currentPage === totalPages - 1}
+                  className={`mx-1 px-3 py-1 rounded ${
+                    currentPage === totalPages - 1
+                      ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                      : 'bg-gray-200 hover:bg-gray-300'
+                  }`}
+                >
+                  다음
+                </button>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/frontend/src/app/admin/reports/posts/page.tsx
+++ b/frontend/src/app/admin/reports/posts/page.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface ReportedPost {
+  reportId: number;
+  boardId: number;
+  boardTitle: string;
+  reportedUserId: number;
+  userReportedCount: number;
+  boardReportedCount: number;
+  reportedAt: string;
+}
+
+export default function ReportedPostsPage() {
+  const router = useRouter();
+  const [posts, setPosts] = useState<ReportedPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [processingIds, setProcessingIds] = useState<number[]>([]);
+  const [token, setToken] = useState<string | null>(null);
+  
+  const PAGE_SIZE = 10;
+
+  useEffect(() => {
+    // 컴포넌트 마운트 시 토큰 가져오기
+    const accessToken = localStorage.getItem('accessToken');
+    if (!accessToken) {
+      router.push('/login');
+      return;
+    }
+    
+    setToken(accessToken);
+    checkAdmin(accessToken);
+  }, [router]);
+
+  const checkAdmin = async (accessToken: string) => {
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/check`, {
+        method: 'GET',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${accessToken}`
+        },
+      });
+
+      if (!response.ok) {
+        router.push('/');
+        return;
+      }
+
+      const isAdminResult = await response.json();
+      
+      if (isAdminResult === true) {
+        setIsAdmin(true);
+        fetchPosts(0, accessToken);
+      } else {
+        router.push('/');
+      }
+    } catch (error) {
+      console.error('관리자 권한 확인 중 오류 발생:', error);
+      router.push('/');
+    }
+  };
+
+  const fetchPosts = async (page: number, accessToken: string) => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/report/boards?page=${page}&size=${PAGE_SIZE}`,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${accessToken}`
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('데이터를 불러오는데 실패했습니다');
+      }
+
+      const data = await response.json();
+      setPosts(data.content || []);
+      setTotalPages(data.totalPages || 1);
+      setCurrentPage(page);
+    } catch (error) {
+      console.error('게시글 데이터 로드 중 오류 발생:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    if (page < 0 || page >= totalPages || !token) return;
+    fetchPosts(page, token);
+  };
+
+  const handleDeletePost = async (boardId: number) => {
+    if (processingIds.includes(boardId) || !token) return;
+    
+    setProcessingIds(prev => [...prev, boardId]);
+    
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/v1/admin/boards/${boardId}/pending`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('게시글 삭제 처리 중 오류가 발생했습니다');
+      }
+
+      // 성공 후 목록에서 해당 게시글 제거
+      setPosts(prev => prev.filter(post => post.boardId !== boardId));
+    } catch (error) {
+      console.error('게시글 삭제 처리 중 오류:', error);
+      alert('게시글 삭제 처리에 실패했습니다.');
+    } finally {
+      setProcessingIds(prev => prev.filter(id => id !== boardId));
+    }
+  };
+
+  if (loading && !posts.length) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  const displayPage = currentPage + 1;
+  const displayTotalPages = totalPages;
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-6 flex justify-between items-center">
+        <h1 className="text-2xl font-bold">신고된 게시글 관리</h1>
+        <Link href="/admin" className="text-blue-600 hover:underline">
+          관리자 홈으로
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center my-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
+        </div>
+      ) : posts.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full bg-white border border-gray-200">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="py-2 px-3 border-b text-left">신고 ID</th>
+                <th className="py-2 px-3 border-b text-left">게시글 ID</th>
+                <th className="py-2 px-3 border-b text-left">게시글 제목</th>
+                <th className="py-2 px-3 border-b text-left">작성자 ID</th>
+                <th className="py-2 px-3 border-b text-left">해당 유저 총 신고 횟수</th>
+                <th className="py-2 px-3 border-b text-left">해당 게시글 신고 횟수</th>
+                <th className="py-2 px-3 border-b text-left">신고 일시</th>
+                <th className="py-2 px-3 border-b text-left">관리</th>
+              </tr>
+            </thead>
+            <tbody>
+              {posts.map((post) => (
+                <tr key={post.reportId} className="hover:bg-gray-50">
+                  <td className="py-2 px-3 border-b">{post.reportId}</td>
+                  <td className="py-2 px-3 border-b">{post.boardId}</td>
+                  <td className="py-2 px-3 border-b max-w-xs truncate">
+                    <Link 
+                      href={`/post/${post.boardId}`} 
+                      className="text-blue-600 hover:underline cursor-pointer"
+                    >
+                      {post.boardTitle}
+                    </Link>
+                  </td>
+                  <td className="py-2 px-3 border-b">
+                    <Link 
+                      href={`/admin/users/${post.reportedUserId}`} 
+                      className="text-blue-600 hover:underline"
+                    >
+                      {post.reportedUserId}
+                    </Link>
+                  </td>
+                  <td className="py-2 px-3 border-b">{post.userReportedCount}</td>
+                  <td className="py-2 px-3 border-b">{post.boardReportedCount}</td>
+                  <td className="py-2 px-3 border-b">
+                    {new Date(post.reportedAt).toLocaleString('ko-KR')}
+                  </td>
+                  <td className="py-2 px-3 border-b">
+                    <button
+                      onClick={() => handleDeletePost(post.boardId)}
+                      disabled={processingIds.includes(post.boardId)}
+                      className={`px-3 py-1 rounded text-white ${
+                        processingIds.includes(post.boardId)
+                          ? 'bg-gray-400'
+                          : 'bg-red-500 hover:bg-red-600'
+                      }`}
+                    >
+                      {processingIds.includes(post.boardId) ? '처리 중...' : '삭제'}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="text-center py-8">
+          <p className="text-gray-500">신고된 게시글이 없습니다.</p>
+        </div>
+      )}
+
+      {/* 페이지네이션 */}
+      {totalPages > 1 && (
+        <div className="flex justify-center mt-6">
+          <nav>
+            <ul className="flex">
+              <li>
+                <button
+                  onClick={() => handlePageChange(currentPage - 1)}
+                  disabled={currentPage === 0}
+                  className={`mx-1 px-3 py-1 rounded ${
+                    currentPage === 0
+                      ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                      : 'bg-gray-200 hover:bg-gray-300'
+                  }`}
+                >
+                  이전
+                </button>
+              </li>
+              {Array.from({ length: displayTotalPages }, (_, i) => i).map((page) => (
+                <li key={page}>
+                  <button
+                    onClick={() => handlePageChange(page)}
+                    className={`mx-1 px-3 py-1 rounded ${
+                      currentPage === page ? 'bg-blue-500 text-white' : 'bg-gray-200 hover:bg-gray-300'
+                    }`}
+                  >
+                    {page + 1}
+                  </button>
+                </li>
+              ))}
+              <li>
+                <button
+                  onClick={() => handlePageChange(currentPage + 1)}
+                  disabled={currentPage === totalPages - 1}
+                  className={`mx-1 px-3 py-1 rounded ${
+                    currentPage === totalPages - 1
+                      ? 'bg-gray-200 text-gray-500 cursor-not-allowed'
+                      : 'bg-gray-200 hover:bg-gray-300'
+                  }`}
+                >
+                  다음
+                </button>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -42,6 +42,17 @@ export default function LoginPage() {
             const data = await response.json()
             console.log('로그인 성공 데이터:', data)
 
+            // 응답 데이터에서 토큰 추출 및 저장
+            if (data.accessToken) {
+                localStorage.setItem('accessToken', data.accessToken)
+                console.log('액세스 토큰 저장 완료')
+            }
+            
+            if (data.refreshToken) {
+                localStorage.setItem('refreshToken', data.refreshToken)
+                console.log('리프레시 토큰 저장 완료')
+            }
+
             //라우터로 보내면 레이아웃이 갱신이 안됨
             window.location.href = '/'
 

--- a/frontend/src/stores/auth/loginMember.tsx
+++ b/frontend/src/stores/auth/loginMember.tsx
@@ -92,6 +92,9 @@ export function useLoginMember() {
             method: 'DELETE',
             credentials: 'include',
         }).then(() => {
+            // 로그아웃 시 액세스 토큰 제거
+            localStorage.removeItem('accessToken')
+            localStorage.removeItem('refreshToken')
             removeLoginMember()
             callback()
         })


### PR DESCRIPTION
## 📒 개요
관리자 모드 신고 댓글,게시물 관리

## 📍 Issue 번호
<!-- 관련있는 이슈 번호(#n)를 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요. -->
> #104

## 🛠️ 작업사항
<!-- 내용을 적어주세요. -->
- 헤더에 관리자 모드로 로그인 했을 때만 관리자 페이지로 가는 버튼 보이게 구현
- 댓글,게시물 신고 되었을 때 대기 상태로 가게 수정
- 대기 상태인 댓글,게시물 조회
- 삭제 버튼 눌러 소프트 삭제 구현
- 좋아요 누른 댓글 조회 기능 삭제 
- 관리자인지 확인하는 로직 구현
- 필터에서 권한 유저 디테일에 저장하는 코드 추가 
- 로그아웃시 토큰 제거 하는 코드 추가
- 토큰 저장 로직
- 게시물 아이디랑 유저 아이디 누르면 상세 페이지로 이동하는 기능은 상세 페이지 구현 후 추가 예정

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/9a9abfe7-a61c-4515-8528-b78906bc29f8)
![image](https://github.com/user-attachments/assets/871a2744-d94c-4156-94f1-0f446cb6c114)
![image](https://github.com/user-attachments/assets/37cd9c24-4f67-488f-8286-e8b0f9e4e4bf)

