### PR TITLE
카톡 프사 뽑기

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -53,3 +53,5 @@ yarn-debug.log
 yarn-error.log
 package-lock.json
 yarn.lock
+
+uploads

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/security/OAuth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/security/OAuth/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.golden_dobakhe.HakPle.global.Status;
 import com.golden_dobakhe.HakPle.security.service.AuthService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -47,10 +48,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String profileImgUrl = attributesProperties.get("profile_image");
         //유저명은 이렇게 설정을 해둔다
         String username = providerTypeCode + "__" + oauthId;
+        System.out.println("이미지 : " + profileImgUrl);
 
 
         //그리고 가입
-        User user = testUserService.modifyOrJoin(username, nickname);
+        User user = testUserService.modifyOrJoin(username, nickname, profileImgUrl);
 
 
         //그리고 시큐리티에게 알려줄 객체를 만든다

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/security/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                                 .requestMatchers(
                                         // OAuth2 및 스웨거 API 문서
-//                                "/oauth2/authorization/kakao?redirectUrl=http://localhost:3000",
+                                "/oauth2/authorization/kakao?redirectUrl=http://localhost:3000",
                                         "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**",
 
                                         // 인증 관련 API

--- a/backend/src/main/java/com/golden_dobakhe/HakPle/security/service/AuthService.java
+++ b/backend/src/main/java/com/golden_dobakhe/HakPle/security/service/AuthService.java
@@ -2,6 +2,10 @@ package com.golden_dobakhe.HakPle.security.service;
 //이 부분은 테스트를 위한 것이며 추후 어딘가에 병합이 될 수 있음
 
 
+import com.golden_dobakhe.HakPle.domain.resource.image.entity.Image;
+import com.golden_dobakhe.HakPle.domain.resource.image.exception.ImageErrorCode;
+import com.golden_dobakhe.HakPle.domain.resource.image.exception.ProfileImageException;
+import com.golden_dobakhe.HakPle.domain.resource.image.repository.ImageRepository;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.Role;
 import com.golden_dobakhe.HakPle.domain.user.user.entity.User;
 import com.golden_dobakhe.HakPle.domain.user.user.repository.UserRepository;
@@ -11,7 +15,11 @@ import com.golden_dobakhe.HakPle.security.jwt.JwtTokenizer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.io.*;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -21,17 +29,22 @@ import java.util.*;
 @Slf4j
 public class AuthService {
     private final UserRepository userRepository;
+    private final ImageRepository imageRepository;
     private final JwtTokenizer jwtTokenizer;
+    private static final String UPLOAD_DIR = "uploads/profile/";
 
     //일단 간단하게 있는지 없는지 체크
+    @Transactional(readOnly = true)
     public User findByUserName(String userName) {
         return userRepository.findByUserName(userName).get();
     }
 
+    @Transactional(readOnly = true)
     public Optional<User> findById(Long userId) {
         return userRepository.findById(userId);
     }
 
+    @Transactional(readOnly = true)
     public String genAccessToken(User user) {
         return jwtTokenizer.createAccessToken(
             user.getId(), 
@@ -43,6 +56,7 @@ public class AuthService {
             user.getAcademyId()
         );
     }
+    @Transactional(readOnly = true)
     public String genRefreshToken(User user) {
         return jwtTokenizer.createRefreshToken(
             user.getId(), 
@@ -55,13 +69,15 @@ public class AuthService {
         );
     }
 
+    @Transactional
     public void addRefreshToken(User user, String refreshToken) {
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
     }
 
     //소셜로그인에 가입한 유저를 새로 만들기
-    public User join(String username, String password, String nickname) {
+    @Transactional
+    public User join(String username, String password, String nickname, String profileImgUrl) {
 
         if (userRepository.existsByUserName(username)) {
             throw new RuntimeException("해당 username은 이미 사용중입니다.");
@@ -83,21 +99,80 @@ public class AuthService {
                 .status(Status.ACTIVE)
                 .build();
 
-        return userRepository.save(user);
+        userRepository.save(user);
+        inputSocialProfileImg(user, profileImgUrl);
+        return user;
     }
 
-    public User modifyOrJoin(String username, String nickname) {
+    @Transactional
+    public String inputSocialProfileImg(User user, String profileImgUrl) {
+        // 1. 저장 경로 설정 (uploadProfileImage에서 쓰는 것과 동일)
+        String uploadPath = System.getProperty("user.dir") + File.separator + UPLOAD_DIR;
+        System.out.println(" 경로 : " + uploadPath);
+        File uploadFolder = new File(uploadPath);
+        if (!uploadFolder.exists()) {
+            uploadFolder.mkdirs();
+        }
+        //2. 파일명 지정
+        //확장자 떼먹기
+        String fileExtension = profileImgUrl.substring(profileImgUrl.lastIndexOf("."));
+        String filename = UUID.randomUUID() + "_" + user.getUserName() + fileExtension;
+        File destinationFile = new File(uploadFolder, filename);
+
+        //3. 이미지 다운로드 및 저장
+        try (InputStream in = new URL(profileImgUrl).openStream();
+             OutputStream out = new FileOutputStream(destinationFile)) {
+            byte[] buffer = new byte[2048];
+            int len;
+            while ((len = in.read(buffer)) != -1) {
+                out.write(buffer, 0, len);
+            }
+        } catch (IOException e) {
+            //return new ProfileImageException(ImageErrorCode.UPLOAD_FAIL);
+        }
+
+        //DB에 저장시킬 이미지 설정
+        String relativePath = "/" + UPLOAD_DIR + filename;
+
+        Image existingImage = imageRepository.findByUser(user);
+
+        if (existingImage != null) {
+            String oldFilePath = System.getProperty("user.dir") + existingImage.getFilePath();
+            File oldFile = new File(oldFilePath);
+            if (oldFile.exists()) {
+                oldFile.delete();
+            }
+            existingImage.setFilePath(relativePath);
+            imageRepository.save(existingImage);
+        }
+        // 등록
+        else {
+            Image newImage = Image.builder()
+                    .user(user)
+                    .filePath(relativePath)
+                    .build();
+            imageRepository.save(newImage);
+            user.setProfileImage(newImage);
+            userRepository.save(user);
+        }
+        return relativePath;
+    }
+
+    @Transactional
+    public User modifyOrJoin(String username, String nickname, String profileImgUrl){
         User user = userRepository.findByUserName(username).orElse(null);
 
         //만약에 있다면 수정
         if (user != null) {
+            inputSocialProfileImg(user, profileImgUrl);
             user.setNickName(nickname);
             return user;
         }
+
         //핸드폰 번호는 없다
         //소셜로그인계정으로 로그인시 아이디,비밀번호를 까먹었다면 해당 소셜 서비스에서 바꾸는게 나을듯
         //없으면 참가
-        return join(username, "", nickname);
+        return join(username, "", nickname, profileImgUrl);
     }
 
 }


### PR DESCRIPTION
## 📒 개요
카카오 로그인시 프로필 사진을 로컬에다 저장합니다



## 🛠️ 작업사항
카카오 로그인시 프로필 사진을 뽑아와서 로컬(추후 DB)에 이미지 파일을 저장하고, 이미지 경로를 mySQL DB에 저장시킵니다

저장 방식은 이전에 만들어두었던 부분을 참고하여 만들었읍니다

특이사항은 프로필을 로그인 할 때 마다 갱신을 시켜서
사이트에서 프로필 바꾸고 카카오 로그인하면 다시 카카오 프로필로 덮어씌어질 듯 합니다
따라서 최초 1회만 카톡 프로필에 있는 부분을 적용시키고, 이후 프로필 변경은 카카오에서 변경해도 적용이 안되고 학플에서만 변경 가능하도록 만들까 생각중입니다
그게 매번 이미지를 빼오지 않아서 더 빠를 것 같기도 하고요



## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/197c5b70-2555-4434-a2fe-f0047bc9611c)
![image](https://github.com/user-attachments/assets/ac7f8905-cbc2-4ef1-92d3-ce46639880ec)
![Uploading image.png…]()
